### PR TITLE
Add Ubuntu/Debian installer and auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,17 @@ Fan control and keyboard lighting for HP Victus / Omen laptops on Linux. Stock f
 - **GNOME Shell integration** exposes fan and keyboard controls from the top panel.
 
 ## Support Matrix
-- **Main installer**: Arch-based distros and Fedora.
+- **Main installer**: Arch-based distros, Fedora, and Ubuntu/Debian-based distros.
 - **Desktop app**: GTK4 app installed by the main project installer.
 - **GNOME Shell extension**: supported on GNOME Shell 45+ and auto-installed by `install.sh` when GNOME is present.
-- **Ubuntu GNOME**: the extension should work on GNOME-based Ubuntu setups if `victus-backend.service` is already installed and reachable, but the project does not currently ship a full Ubuntu installer.
+- **Ubuntu / Debian**: contributor-tested on Ubuntu 24.04 LTS (GNOME 46). Other Debian-based distros use the same installer path but are less tested.
 
 ## System Requirements
 - 64-bit Linux with `systemd`.
 - Supported installer targets:
   - Arch-based distros via `pacman`
   - Fedora via `dnf`
+  - Ubuntu/Debian-based distros via `apt-get`
 - GNOME Shell 45+ if you want the panel extension.
 - Root privileges for installing the DKMS module, sudoers rules, and systemd units.
 
@@ -45,13 +46,18 @@ git clone https://github.com/Batuhan4/victus-control.git
 cd victus-control
 sudo ./install.sh
 ```
-The wrapper routes to `arch-install.sh` or `fedora-install.sh` based on your OS.
+The wrapper routes to `arch-install.sh`, `fedora-install.sh`, or `ubuntu-install.sh` based on your OS.
 On GNOME systems, it also installs the panel extension for the desktop user automatically.
 
 ### Fedora notes
 - Validated by contributors on `HP Victus 16-S0046NT` with Fedora 43.
 - The Fedora installer now verifies that the patched `hp_wmi` module is actually active before starting the backend.
 - If you recently updated the kernel, reboot first so the running kernel matches the installed `kernel-devel` package.
+
+### Ubuntu / Debian notes
+- Contributor-tested on Ubuntu 24.04 LTS (GNOME 46) with an HP Victus 16.
+- The installer accepts DKMS-managed `hp_wmi` module layouts used by both `/extra` and `/updates/dkms`.
+- Secure Boot can block the DKMS module from loading. If install succeeds but `hp_wmi` still does not load, enroll the MOK key with `sudo mokutil --import /var/lib/shim-signed/mok/MOK.der` or disable Secure Boot, then reboot.
 
 The installer handles dependency install, user/group creation, DKMS module registration, build + install, and restarts `victus-backend.service`. Log out/in afterwards so your user joins the `victus` group.
 

--- a/arch-install.sh
+++ b/arch-install.sh
@@ -36,14 +36,38 @@ warn_if_keyboard_interface_missing() {
     fi
 }
 
+resolve_hp_wmi_module_path() {
+    modprobe --show-depends hp_wmi 2>/dev/null \
+        | awk '$1 == "insmod" && $2 ~ /\/hp-wmi\.ko($|\.(gz|xz|zst)$)/ { print $2 }' \
+        | tail -n 1
+}
+
+hp_wmi_module_path_is_dkms() {
+    local module_path="${1:-}"
+
+    case "${module_path}" in
+        */extra/hp-wmi.ko|*/extra/hp-wmi.ko.*|*/updates/hp-wmi.ko|*/updates/hp-wmi.ko.*|*/updates/dkms/hp-wmi.ko|*/updates/dkms/hp-wmi.ko.*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 reload_patched_hp_wmi() {
     local attempts=0
+    local module_path=""
 
     echo "--> Reloading patched hp-wmi module..."
     modprobe led_class_multicolor >/dev/null 2>&1 || true
 
-    if ! modprobe --show-depends hp_wmi | grep -q '/extra/hp-wmi\.ko'; then
-        echo "Error: modprobe hp_wmi is not resolving to the DKMS-installed module in /extra." >&2
+    module_path="$(resolve_hp_wmi_module_path || true)"
+    if ! hp_wmi_module_path_is_dkms "${module_path}"; then
+        if [[ -n "${module_path}" ]]; then
+            echo "Error: modprobe hp_wmi resolved to an unexpected module path: ${module_path}" >&2
+        else
+            echo "Error: Unable to determine which hp_wmi module modprobe would load." >&2
+        fi
         return 1
     fi
 
@@ -67,7 +91,7 @@ reload_patched_hp_wmi() {
 }
 
 install_arch_dependencies() {
-    local packages=(meson ninja gtk4 git dkms)
+    local packages=(meson ninja gtk4 git dkms sudo)
     declare -A header_packages=()
     local module_dir=""
     local pkgbase_path=""

--- a/backend/victus-healthcheck.sh
+++ b/backend/victus-healthcheck.sh
@@ -22,6 +22,24 @@ warn_if_keyboard_interface_missing() {
     fi
 }
 
+resolve_hp_wmi_module_path() {
+    modprobe --show-depends hp_wmi 2>/dev/null \
+        | awk '$1 == "insmod" && $2 ~ /\/hp-wmi\.ko($|\.(gz|xz|zst)$)/ { print $2 }' \
+        | tail -n 1
+}
+
+hp_wmi_module_path_is_dkms() {
+    local module_path="${1:-}"
+
+    case "${module_path}" in
+        */extra/hp-wmi.ko|*/extra/hp-wmi.ko.*|*/updates/hp-wmi.ko|*/updates/hp-wmi.ko.*|*/updates/dkms/hp-wmi.ko|*/updates/dkms/hp-wmi.ko.*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 if ! command -v dkms >/dev/null 2>&1; then
     echo "$log_prefix dkms command not found; skipping kernel module verification" >&2
     exit 0
@@ -38,8 +56,13 @@ if [[ ! "$status_output" =~ ${current_kernel}.*installed ]]; then
     fi
 fi
 
-if ! modprobe --show-depends hp_wmi | grep -q '/extra/hp-wmi\.ko'; then
-    echo "$log_prefix warning: modprobe hp_wmi is not resolving to the DKMS-installed module" >&2
+module_path="$(resolve_hp_wmi_module_path || true)"
+if ! hp_wmi_module_path_is_dkms "${module_path}"; then
+    if [[ -n "${module_path}" ]]; then
+        echo "$log_prefix warning: modprobe hp_wmi resolved to an unexpected module path: ${module_path}" >&2
+    else
+        echo "$log_prefix warning: unable to determine which hp_wmi module modprobe would load" >&2
+    fi
 fi
 
 if ! lsmod | grep -q '^hp_wmi' || ! hp_wmi_fan_interface_ready; then

--- a/fedora-install.sh
+++ b/fedora-install.sh
@@ -36,14 +36,38 @@ warn_if_keyboard_interface_missing() {
     fi
 }
 
+resolve_hp_wmi_module_path() {
+    modprobe --show-depends hp_wmi 2>/dev/null \
+        | awk '$1 == "insmod" && $2 ~ /\/hp-wmi\.ko($|\.(gz|xz|zst)$)/ { print $2 }' \
+        | tail -n 1
+}
+
+hp_wmi_module_path_is_dkms() {
+    local module_path="${1:-}"
+
+    case "${module_path}" in
+        */extra/hp-wmi.ko|*/extra/hp-wmi.ko.*|*/updates/hp-wmi.ko|*/updates/hp-wmi.ko.*|*/updates/dkms/hp-wmi.ko|*/updates/dkms/hp-wmi.ko.*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 reload_patched_hp_wmi() {
     local attempts=0
+    local module_path=""
 
     echo "--> Reloading patched hp-wmi module..."
     modprobe led_class_multicolor >/dev/null 2>&1 || true
 
-    if ! modprobe --show-depends hp_wmi | grep -q '/extra/hp-wmi\.ko'; then
-        echo "Error: modprobe hp_wmi is not resolving to the DKMS-installed module in /extra." >&2
+    module_path="$(resolve_hp_wmi_module_path || true)"
+    if ! hp_wmi_module_path_is_dkms "${module_path}"; then
+        if [[ -n "${module_path}" ]]; then
+            echo "Error: modprobe hp_wmi resolved to an unexpected module path: ${module_path}" >&2
+        else
+            echo "Error: Unable to determine which hp_wmi module modprobe would load." >&2
+        fi
         return 1
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,10 @@ detect_target() {
             echo arch
             return 0
             ;;
+        *" ubuntu "*|*" debian "*|*" linuxmint "*|*" pop "*)
+            echo ubuntu
+            return 0
+            ;;
     esac
 
     if command -v dnf >/dev/null 2>&1; then
@@ -81,6 +85,11 @@ detect_target() {
 
     if command -v pacman >/dev/null 2>&1; then
         echo arch
+        return 0
+    fi
+
+    if command -v apt-get >/dev/null 2>&1; then
+        echo ubuntu
         return 0
     fi
 
@@ -96,8 +105,11 @@ case "${target}" in
     arch)
         "${script_dir}/arch-install.sh" "$@"
         ;;
+    ubuntu)
+        "${script_dir}/ubuntu-install.sh" "$@"
+        ;;
     *)
-        echo "Unsupported distribution. Use arch-install.sh or fedora-install.sh directly." >&2
+        echo "Unsupported distribution. Use arch-install.sh, fedora-install.sh, or ubuntu-install.sh directly." >&2
         exit 1
         ;;
 esac

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -33,14 +33,38 @@ warn_if_keyboard_interface_missing() {
     fi
 }
 
+resolve_hp_wmi_module_path() {
+    modprobe --show-depends hp_wmi 2>/dev/null \
+        | awk '$1 == "insmod" && $2 ~ /\/hp-wmi\.ko($|\.(gz|xz|zst)$)/ { print $2 }' \
+        | tail -n 1
+}
+
+hp_wmi_module_path_is_dkms() {
+    local module_path="${1:-}"
+
+    case "${module_path}" in
+        */extra/hp-wmi.ko|*/extra/hp-wmi.ko.*|*/updates/hp-wmi.ko|*/updates/hp-wmi.ko.*|*/updates/dkms/hp-wmi.ko|*/updates/dkms/hp-wmi.ko.*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 reload_patched_hp_wmi() {
     local attempts=0
+    local module_path=""
 
     echo "--> Reloading patched hp-wmi module..."
     modprobe led_class_multicolor >/dev/null 2>&1 || true
 
-    if ! modprobe --show-depends hp_wmi | grep -q '/extra/hp-wmi\.ko'; then
-        echo "Error: modprobe hp_wmi is not resolving to the DKMS-installed module in /extra." >&2
+    module_path="$(resolve_hp_wmi_module_path || true)"
+    if ! hp_wmi_module_path_is_dkms "${module_path}"; then
+        if [[ -n "${module_path}" ]]; then
+            echo "Error: modprobe hp_wmi resolved to an unexpected module path: ${module_path}" >&2
+        else
+            echo "Error: Unable to determine which hp_wmi module modprobe would load." >&2
+        fi
         return 1
     fi
 
@@ -74,6 +98,7 @@ install_ubuntu_dependencies() {
         git \
         dkms \
         g++ \
+        sudo \
         "linux-headers-${current_kernel}"
 }
 

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "This script requires root privileges. Re-running with sudo..."
+    exec sudo "$0" "$@"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${script_dir}"
+
+module_name="hp-wmi-fan-and-backlight-control"
+module_version="0.0.2"
+
+verify_hp_wmi_fan_interface() {
+    local hwmon_path
+    hwmon_path="$(find /sys/devices/platform/hp-wmi/hwmon -mindepth 1 -maxdepth 1 -type d -name 'hwmon*' | head -n 1 || true)"
+    if [[ -z "${hwmon_path}" ]]; then
+        echo "Error: hp_wmi hwmon directory not found." >&2
+        return 1
+    fi
+    if [[ ! -e "${hwmon_path}/fan1_target" || ! -e "${hwmon_path}/fan2_target" ]]; then
+        echo "Error: Patched hp_wmi fan target controls are missing under ${hwmon_path}." >&2
+        return 1
+    fi
+    return 0
+}
+
+warn_if_keyboard_interface_missing() {
+    if [[ ! -e /sys/class/leds/hp::kbd_backlight && ! -e /sys/devices/platform/hp-wmi/rgb_zones/zone00 ]]; then
+        echo "Warning: Patched hp_wmi keyboard lighting interface was not detected. Fan control can still work on this model." >&2
+    fi
+}
+
+reload_patched_hp_wmi() {
+    local attempts=0
+
+    echo "--> Reloading patched hp-wmi module..."
+    modprobe led_class_multicolor >/dev/null 2>&1 || true
+
+    if ! modprobe --show-depends hp_wmi | grep -q '/extra/hp-wmi\.ko'; then
+        echo "Error: modprobe hp_wmi is not resolving to the DKMS-installed module in /extra." >&2
+        return 1
+    fi
+
+    if lsmod | grep -q '^hp_wmi\b'; then
+        modprobe -r hp_wmi || rmmod hp_wmi
+    fi
+
+    modprobe hp_wmi
+
+    until verify_hp_wmi_fan_interface; do
+        attempts=$((attempts + 1))
+        if (( attempts >= 3 )); then
+            return 1
+        fi
+        sleep 1
+    done
+
+    warn_if_keyboard_interface_missing
+    return 0
+}
+
+install_ubuntu_dependencies() {
+    local current_kernel
+    current_kernel="$(uname -r)"
+
+    apt-get update -q
+    apt-get install -y \
+        meson \
+        ninja-build \
+        libgtk-4-dev \
+        git \
+        dkms \
+        g++ \
+        "linux-headers-${current_kernel}"
+}
+
+ensure_users_and_groups() {
+    echo "--> Creating secure users and groups..."
+
+    if ! getent group victus >/dev/null; then
+        groupadd --system victus
+        echo "Group 'victus' created."
+    else
+        echo "Group 'victus' already exists."
+    fi
+
+    if ! getent group victus-backend >/dev/null; then
+        groupadd --system victus-backend
+        echo "Group 'victus-backend' created."
+    else
+        echo "Group 'victus-backend' already exists."
+    fi
+
+    if ! id -u victus-backend >/dev/null 2>&1; then
+        useradd --system -g victus-backend -s /usr/sbin/nologin victus-backend
+        echo "User 'victus-backend' created."
+    else
+        echo "User 'victus-backend' already exists."
+    fi
+
+    if ! groups victus-backend | grep -q '\bvictus\b'; then
+        usermod -aG victus victus-backend
+        echo "User 'victus-backend' added to the 'victus' group."
+    fi
+
+    if [[ -n "${SUDO_USER:-}" ]] && ! groups "${SUDO_USER}" | grep -q '\bvictus\b'; then
+        usermod -aG victus "${SUDO_USER}"
+        echo "User '${SUDO_USER}' added to the 'victus' group."
+    fi
+}
+
+install_helpers_and_sudoers() {
+    echo "--> Installing helper scripts and sudoers..."
+    install -m 0755 backend/src/set-fan-speed.sh /usr/bin/set-fan-speed.sh
+    install -m 0755 backend/src/set-fan-mode.sh /usr/bin/set-fan-mode.sh
+    install -m 0755 backend/src/set-rgb-zone.sh /usr/bin/set-rgb-zone.sh
+    rm -f /etc/sudoers.d/victus-fan-sudoers
+    install -m 0440 victus-control-sudoers /etc/sudoers.d/victus-control-sudoers
+    if command -v visudo >/dev/null 2>&1; then
+        visudo -cf /etc/sudoers.d/victus-control-sudoers >/dev/null
+    fi
+}
+
+install_hp_wmi_dkms() {
+    local wmi_root="wmi-project"
+    local wmi_repo="${wmi_root}/hp-wmi-fan-and-backlight-control"
+    local current_kernel
+
+    echo "--> Installing patched hp-wmi kernel module..."
+    mkdir -p "${wmi_root}"
+
+    if [[ -d "${wmi_repo}/.git" ]]; then
+        git -C "${wmi_repo}" fetch origin master
+        git -C "${wmi_repo}" reset --hard origin/master
+    else
+        git clone https://github.com/Batuhan4/hp-wmi-fan-and-backlight-control.git "${wmi_repo}"
+    fi
+
+    pushd "${wmi_repo}" >/dev/null
+
+    if dkms status -m "${module_name}" -v "${module_version}" >/dev/null 2>&1; then
+        dkms remove "${module_name}/${module_version}" --all || true
+    fi
+
+    dkms add .
+    current_kernel="$(uname -r)"
+    dkms install "${module_name}/${module_version}" -k "${current_kernel}"
+
+    popd >/dev/null
+
+    reload_patched_hp_wmi
+}
+
+build_and_install_app() {
+    echo "--> Building and installing the application..."
+    meson setup build --wipe --prefix=/usr
+    meson compile -C build
+    meson install -C build
+
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database /usr/share/applications || true
+    fi
+
+    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+        gtk-update-icon-cache -q -t -f /usr/share/icons/hicolor || true
+    fi
+}
+
+start_services() {
+    echo "--> Configuring and starting backend service..."
+    systemd-tmpfiles --create || echo "Warning: Failed to create tmpfiles, continuing..."
+    systemctl daemon-reload
+    udevadm control --reload-rules
+    udevadm trigger --subsystem-match=hwmon --subsystem-match=leds || true
+    udevadm settle || true
+
+    systemctl enable --now victus-healthcheck.service || true
+    systemctl enable --now victus-backend.service
+    sleep 2
+    systemctl is-active --quiet victus-backend.service
+}
+
+echo "--- Starting Victus Control Installation (Ubuntu) ---"
+echo "--> Installing required packages..."
+install_ubuntu_dependencies
+ensure_users_and_groups
+install_helpers_and_sudoers
+install_hp_wmi_dkms
+build_and_install_app
+start_services
+
+echo
+echo "--- Installation Complete! ---"
+echo
+echo "IMPORTANT: For the group changes to take full effect, please log out and log back in."
+echo "After logging back in, you can launch the application from your desktop menu or by running 'victus-control'."


### PR DESCRIPTION
## Summary

- Adds `ubuntu-install.sh`: a full installer for Ubuntu/Debian-based distros, mirroring the Fedora installer but using `apt`. Tested on **Ubuntu 24.04 LTS with GNOME 46** on an **HP Victus 16**.
- `install.sh` now auto-detects Ubuntu/Debian via `/etc/os-release` (matching `ubuntu`, `debian`, `linuxmint`, `pop`) with an `apt-get` fallback, routing to `ubuntu-install.sh`.

## What the Ubuntu installer does

Same pipeline as `fedora-install.sh`:
1. Installs deps via `apt-get`: `meson`, `ninja-build`, `libgtk-4-dev`, `linux-headers-$(uname -r)`, `dkms`, `g++`, `git`
2. Creates `victus` / `victus-backend` groups and `victus-backend` system user
3. Installs helper scripts and sudoers rules
4. Clones and builds the `hp-wmi-fan-and-backlight-control` DKMS module
5. Builds and installs the GTK4 app + backend via meson
6. Installs udev rules and starts `victus-backend.service`

## Hardware tested

| Model | OS | GNOME | Result |
|---|---|---|---|
| HP Victus 16 | Ubuntu 24.04 LTS | 46.0 | ✅ Working |

## Secure Boot note

Users with Secure Boot enabled must either:
- Disable Secure Boot in BIOS (simplest), or
- Enroll the shim MOK key: `sudo mokutil --import /var/lib/shim-signed/mok/MOK.der`, then reboot and confirm in the MokManager screen

## Test plan

- [ ] `sudo ./install.sh` completes without errors on Ubuntu 24.04
- [ ] `systemctl is-active victus-backend.service` returns `active`
- [ ] Fan mode switching works in the GTK app and GNOME extension
- [ ] `gnome-extensions enable victus-control@victus` enables the panel extension