### PR TITLE
fix: add CachyOS support and RGB zone permissions

### DIFF
--- a/99-hp-wmi-permissions.rules
+++ b/99-hp-wmi-permissions.rules
@@ -7,3 +7,5 @@ SUBSYSTEM=="hwmon", KERNELS=="hp-wmi", GROUP="victus", MODE="0664"
 SUBSYSTEM=="hwmon", KERNELS=="hp-wmi", ACTION=="add|change", RUN+="/usr/bin/sh -c '/usr/bin/chgrp victus /sys%p/pwm1_enable /sys%p/fan1_target /sys%p/fan2_target 2>/dev/null; /usr/bin/chmod g+w /sys%p/pwm1_enable /sys%p/fan1_target /sys%p/fan2_target 2>/dev/null'"
 
 SUBSYSTEM=="leds", KERNEL=="hp::kbd_backlight", ACTION=="add|change", RUN+="/usr/bin/sh -c '/usr/bin/chgrp victus /sys%p/brightness /sys%p/multi_intensity 2>/dev/null; /usr/bin/chmod g+w /sys%p/brightness /sys%p/multi_intensity 2>/dev/null'"
+
+SUBSYSTEM=="platform", KERNEL=="hp-wmi", ACTION=="add|change", RUN+="/usr/bin/sh -c '/usr/bin/chgrp -R victus /sys/devices/platform/hp-wmi/rgb_zones 2>/dev/null; /usr/bin/chmod -R g+rw /sys/devices/platform/hp-wmi/rgb_zones 2>/dev/null'"

--- a/arch-install.sh
+++ b/arch-install.sh
@@ -42,8 +42,13 @@ reload_patched_hp_wmi() {
     echo "--> Reloading patched hp-wmi module..."
     modprobe led_class_multicolor >/dev/null 2>&1 || true
 
-    if ! modprobe --show-depends hp_wmi | grep -q '/extra/hp-wmi\.ko'; then
-        echo "Error: modprobe hp_wmi is not resolving to the DKMS-installed module in /extra." >&2
+    local module_path="/extra/hp-wmi\.ko"
+    if grep -q '^ID=cachyos' /etc/os-release 2>/dev/null; then
+        module_path="/updates/.*hp-wmi\.ko\.zst"
+    fi
+
+    if ! modprobe --show-depends hp_wmi | grep -E -q "$module_path"; then
+        echo "Error: modprobe hp_wmi is not resolving to the DKMS-installed module (checked $module_path)." >&2
         return 1
     fi
 


### PR DESCRIPTION
This PR adds support for CachyOS and improves hardware compatibility for RGB keyboards.

Changes:
- **CachyOS Support**: Added detection for CachyOS in `arch-install.sh`. When CachyOS is detected, the installer now correctly searches for the DKMS-installed `hp-wmi` module in `/updates/` instead of `/extra/`, matching the CachyOS kernel layout.
- **RGB Keyboard Support**: Updated udev rules in `99-hp-wmi-permissions.rules` to correctly set permissions for RGB zones, allowing non-root access to keyboard backlight controls on supported Victus models.

Verified on CachyOS.