### PR TITLE
feat(hotkey): open the dashboard from the OMEN key

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ privileged backend, a GTK4 desktop app, and a GNOME Shell extension.
 - [Secure Boot / userspace alternative](#secure-boot--userspace-alternative)
 - [System requirements](#system-requirements)
 - [Install & update](#install--update)
+- [The OMEN key](#the-omen-key)
 - [Daily usage](#daily-usage)
 - [Lighting effects](#lighting-effects)
 - [GNOME Shell extension](#gnome-shell-extension)
@@ -158,12 +159,53 @@ The installer handles dependency install, user/group creation, DKMS module regis
 | --- | --- |
 | `victus-healthcheck.service` | Runs at boot to ensure the patched `hp-wmi` DKMS module is built for the current kernel and `hp_wmi` is loaded before the backend starts |
 | `victus-backend.service` | Starts at boot and stays active, keeping Better Auto and the lighting applied even with no UI client connected |
+| `victus-hotkeyd.service` | A **user** unit that watches for the dedicated OMEN key and opens the dashboard. See [The OMEN key](#the-omen-key) |
+
+---
+
+## The OMEN key
+
+The dedicated OMEN key above the keyboard opens Victus Control.
+
+The `hp-wmi` driver reports that key on its `HP WMI hotkeys` input device as
+`KEY_PROG2` (scancodes `0x21a5` and `0x21a8` both map to it). `victus-hotkeyd`
+watches for it and runs `victus-control`. The app is a single instance, so
+pressing the key again raises the window that is already open rather than
+stacking up a second dashboard.
+
+It runs as a *user* service, not a system one, because it has to launch a GUI
+into the session that owns the display:
+
+```bash
+systemctl --user status victus-hotkeyd.service
+systemctl --user disable --now victus-hotkeyd.service   # to turn it off
+```
+
+Reading the hotkey device needs permission, which
+`/etc/udev/rules.d/99-victus-hotkey.rules` grants to the `victus` group. That
+device only carries the firmware hotkeys — brightness, mic mute, OMEN — never
+the typing keyboard, so this does not expose keystrokes. It is deliberately
+narrower than adding your user to the `input` group, which would hand over every
+input device including the real keyboard.
+
+If the key does nothing, check in this order:
+
+```bash
+systemctl --user is-active victus-hotkeyd     # should print "active"
+ls -l /dev/input/by-path/*event-kbd           # device present at all?
+journalctl --user -u victus-hotkeyd -n 20     # should say it is watching
+```
+
+The event node number is not stable across reboots or DKMS rebuilds, so the
+daemon finds the device by name and re-scans every 5 s if it disappears — a
+module reload does not require restarting the service.
 
 ---
 
 ## Daily usage
 
 Launch the GTK app (`victus-control`) or use the CLI client (`test_backend.py`).
+Press the OMEN key, or pick it from the desktop menu.
 
 Everything lives on one page, with a card per subsystem.
 

--- a/backend/src/set-fan-mode.sh
+++ b/backend/src/set-fan-mode.sh
@@ -35,6 +35,17 @@ if [[ -z "${HWMON_PATH}" ]]; then
     exit 3
 fi
 
+# MANUAL (and BETTER_AUTO, which drives the fans through MANUAL) needs
+# fanN_target to set a speed once the firmware curve is off. On boards that
+# expose no target (e.g. 8E5F / Victus 15-fb3xxx) that combination strands the
+# fans at whatever RPM they happened to be at, with nothing managing cooling.
+# AUTO and MAX are both driven by pwm1_enable alone, so they stay available.
+if [[ "${value}" == "1" ]] && [[ ! -e "${HWMON_PATH}/fan1_target" ]]; then
+    echo "Refusing mode '${mode}': no fan1_target on this board, so no speed could be set." >&2
+    echo "Keeping the firmware AUTO curve. Use MAX for full fans." >&2
+    value="2"
+fi
+
 CONTROL_FILE="${HWMON_PATH}/pwm1_enable"
 if [[ ! -w "${CONTROL_FILE}" ]]; then
     # Attempt to adjust permissions for diagnostics, but continue even if it fails.

--- a/frontend/src/main.cpp
+++ b/frontend/src/main.cpp
@@ -24,13 +24,16 @@ public:
 	std::unique_ptr<VictusKeyboardControl> keyboard_control;
 	VictusAbout about;
 
-	VictusControl()
+	explicit VictusControl(GtkApplication *application)
 	{
 		socket_client = std::make_shared<VictusSocketClient>("/run/victus-control/victus_backend.sock");
 		fan_control = std::make_unique<VictusFanControl>(socket_client);
 		keyboard_control = std::make_unique<VictusKeyboardControl>(socket_client);
 
-		window = gtk_window_new();
+		// Tying the window to the application is what makes the process a
+		// single instance: a second launch (the OMEN key, the .desktop entry)
+		// re-activates this one instead of building a second dashboard.
+		window = gtk_application_window_new(application);
 		gtk_window_set_title(GTK_WINDOW(window), "VICTUS CONTROL");
 		gtk_window_set_default_size(GTK_WINDOW(window), 900, 900);
 
@@ -93,20 +96,12 @@ public:
 		gtk_header_bar_set_show_title_buttons(GTK_HEADER_BAR(header_bar), TRUE);
 	}
 
-	void run()
+	// Shows the dashboard, or raises it if it is already open behind other
+	// windows. GtkApplication owns the main loop and quits when the last
+	// window closes, so there is no loop to run here.
+	void present()
 	{
-		GMainLoop *loop = g_main_loop_new(nullptr, FALSE);
-
-		g_signal_connect(window, "destroy", G_CALLBACK(+[](GtkWidget *, gpointer loop)
-		{
-			g_main_loop_quit(static_cast<GMainLoop *>(loop));
-		}), loop);
-
-		gtk_widget_set_visible(window, true);
-
-		g_main_loop_run(loop);
-
-		g_main_loop_unref(loop);
+		gtk_window_present(GTK_WINDOW(window));
 	}
 
 private:
@@ -118,40 +113,82 @@ private:
 	}
 };
 
-int main(int argc, char *argv[])
-{
-	gtk_init();
-	apply_victus_style();
+// The name the single-instance lock is taken under, so it must stay stable:
+// change it and a running instance stops answering new launches. The .desktop
+// file carries a matching StartupWMClass so the shell still pairs the window
+// with the launcher.
+#define APPLICATION_ID "io.github.batuhan4.victus-control"
 
-	try {
-		VictusControl app;
-		app.run();
-	} catch (const std::exception &e) {
-		std::cerr << "An unhandled exception occurred: " << e.what() << std::endl;
-		GtkWidget *error_dialog = gtk_message_dialog_new(
-			nullptr,
-			GTK_DIALOG_DESTROY_WITH_PARENT,
-			GTK_MESSAGE_ERROR,
-			GTK_BUTTONS_CLOSE,
-			"An error occurred: %s",
-			e.what()
-		);
-		gtk_window_set_title(GTK_WINDOW(error_dialog), "Error");
-		GMainLoop *loop = g_main_loop_new(nullptr, FALSE);
-		g_signal_connect(error_dialog, "response", G_CALLBACK(+[](GtkDialog *dialog, int, gpointer user_data) {
-			g_main_loop_quit(static_cast<GMainLoop *>(user_data));
-			gtk_window_destroy(GTK_WINDOW(dialog));
-		}), loop);
-		g_signal_connect(error_dialog, "close-request", G_CALLBACK(+[](GtkWidget *, gpointer user_data) {
-			g_main_loop_quit(static_cast<GMainLoop *>(user_data));
-			return FALSE;
-		}), loop);
-		gtk_widget_set_visible(error_dialog, true);
-		g_main_loop_run(loop);
-		g_main_loop_unref(loop);
-		return 1;
+namespace {
+
+struct AppState
+{
+	std::unique_ptr<VictusControl> control;
+	bool failed = false;
+};
+
+void show_error_dialog(GtkApplication *application, const char *message)
+{
+	GtkWidget *error_dialog = gtk_message_dialog_new(
+		nullptr,
+		GTK_DIALOG_DESTROY_WITH_PARENT,
+		GTK_MESSAGE_ERROR,
+		GTK_BUTTONS_CLOSE,
+		"An error occurred: %s",
+		message
+	);
+	gtk_window_set_title(GTK_WINDOW(error_dialog), "Error");
+
+	// Hold the application so it does not exit before the dialog is dismissed;
+	// the dialog is not an application window, so it does not keep it alive.
+	g_application_hold(G_APPLICATION(application));
+	g_signal_connect(error_dialog, "response", G_CALLBACK(+[](GtkDialog *dialog, int, gpointer user_data) {
+		gtk_window_destroy(GTK_WINDOW(dialog));
+		g_application_release(G_APPLICATION(user_data));
+	}), application);
+
+	gtk_widget_set_visible(error_dialog, true);
+}
+
+// Runs on the first launch and again on every re-activation, including the one
+// the OMEN key triggers by re-running the binary.
+void on_activate(GtkApplication *application, gpointer user_data)
+{
+	AppState *state = static_cast<AppState *>(user_data);
+
+	if (state->failed)
+		return;
+
+	if (!state->control) {
+		try {
+			apply_victus_style();
+			state->control = std::make_unique<VictusControl>(application);
+		} catch (const std::exception &e) {
+			std::cerr << "An unhandled exception occurred: " << e.what() << std::endl;
+			state->failed = true;
+			show_error_dialog(application, e.what());
+			return;
+		}
 	}
 
+	state->control->present();
+}
 
-	return 0;
+}  // namespace
+
+int main(int argc, char *argv[])
+{
+	AppState state;
+
+	GtkApplication *application = gtk_application_new(APPLICATION_ID, G_APPLICATION_DEFAULT_FLAGS);
+	g_signal_connect(application, "activate", G_CALLBACK(on_activate), &state);
+
+	int status = g_application_run(G_APPLICATION(application), argc, argv);
+
+	// Tear the window down before GTK shuts down, so the socket client and the
+	// control objects are destroyed while their GTK widgets are still valid.
+	state.control.reset();
+	g_object_unref(application);
+
+	return state.failed ? 1 : status;
 }

--- a/frontend/victus-control.desktop
+++ b/frontend/victus-control.desktop
@@ -6,3 +6,4 @@ Icon=victus-icon
 Terminal=false
 Type=Application
 Categories=Utility;
+StartupWMClass=io.github.batuhan4.victus-control

--- a/hotkey/99-victus-hotkey.rules
+++ b/hotkey/99-victus-hotkey.rules
@@ -1,0 +1,12 @@
+# /etc/udev/rules.d/99-victus-hotkey.rules
+#
+# victus-hotkeyd runs as a user service, so it needs to read the HP WMI hotkey
+# device to see the OMEN key. Access goes to the victus group, matching how the
+# fan and backlight nodes are handled in 99-hp-wmi-permissions.rules.
+#
+# This device only carries the firmware hotkeys -- brightness, mic mute, OMEN --
+# and never the typing keyboard, which stays root-only. Read access is granted
+# rather than adding anyone to the input group, which would expose every input
+# device including the real keyboard.
+
+SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="HP WMI hotkeys", GROUP="victus", MODE="0640"

--- a/hotkey/meson.build
+++ b/hotkey/meson.build
@@ -1,0 +1,16 @@
+executable('victus-hotkeyd',
+  sources: ['src/main.cpp'],
+  install: true,
+  install_dir: get_option('bindir'))
+
+# A user unit, not a system one: it launches a GUI, so it has to live in the
+# session that owns the display.
+install_data(
+	'victus-hotkeyd.service',
+	install_dir: '/usr/lib/systemd/user'
+)
+
+install_data(
+	'99-victus-hotkey.rules',
+	install_dir: '/etc/udev/rules.d'
+)

--- a/hotkey/src/main.cpp
+++ b/hotkey/src/main.cpp
@@ -1,0 +1,165 @@
+// victus-hotkeyd -- opens Victus Control when the dedicated OMEN key is pressed.
+//
+// The hp-wmi driver reports the OMEN key on its "HP WMI hotkeys" input device.
+// On this keymap two scancodes, 0x21a5 and 0x21a8, both resolve to KEY_PROG2,
+// so the daemon matches on the keycode rather than on either scancode.
+//
+// Nothing here talks to the backend: it re-runs the GUI binary, which is a
+// single instance, so the second press raises the window that is already open.
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstring>
+#include <dirent.h>
+#include <fcntl.h>
+#include <iostream>
+#include <linux/input.h>
+#include <poll.h>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+
+namespace {
+
+constexpr char kDeviceName[] = "HP WMI hotkeys";
+constexpr char kAppBinary[] = "/usr/bin/victus-control";
+constexpr int kOmenKey = KEY_PROG2;
+
+// The firmware sometimes reports one physical press twice; collapse those so a
+// single press does not race two launches of the GUI against each other.
+constexpr auto kDebounce = std::chrono::milliseconds(400);
+
+// How long to wait before re-scanning when the input device is absent, which
+// happens while hp_wmi is being reloaded (an install, or a DKMS rebuild).
+constexpr auto kRescanDelay = std::chrono::seconds(5);
+
+std::atomic<bool> g_running{true};
+
+void on_signal(int)
+{
+  g_running = false;
+}
+
+// Locates the hotkey device by name. The event node number is not stable across
+// boots or module reloads, so it must not be hardcoded.
+int open_hotkey_device()
+{
+  DIR *dir = opendir("/dev/input");
+  if (dir == nullptr)
+    return -1;
+
+  int found = -1;
+  while (dirent *entry = readdir(dir)) {
+    if (std::strncmp(entry->d_name, "event", 5) != 0)
+      continue;
+
+    const std::string path = std::string("/dev/input/") + entry->d_name;
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+      continue;
+
+    char name[256] = {};
+    if (ioctl(fd, EVIOCGNAME(sizeof(name) - 1), name) >= 0 &&
+        std::strcmp(name, kDeviceName) == 0) {
+      found = fd;
+      break;
+    }
+
+    close(fd);
+  }
+
+  closedir(dir);
+  return found;
+}
+
+// Double-forks so the GUI is reparented to init: the daemon never waits on it
+// and never accumulates zombies, however many times the key is pressed.
+void launch_app()
+{
+  const pid_t intermediate = fork();
+  if (intermediate < 0) {
+    std::cerr << "victus-hotkeyd: fork failed: " << std::strerror(errno) << std::endl;
+    return;
+  }
+
+  if (intermediate == 0) {
+    if (fork() == 0) {
+      execl(kAppBinary, kAppBinary, static_cast<char *>(nullptr));
+      _exit(127);
+    }
+    _exit(0);
+  }
+
+  waitpid(intermediate, nullptr, 0);
+}
+
+// Reads key events until the device goes away or a signal arrives.
+void watch_device(int fd, std::chrono::steady_clock::time_point &last_press)
+{
+  while (g_running) {
+    pollfd pfd{fd, POLLIN, 0};
+    const int ready = poll(&pfd, 1, 1000);
+
+    if (ready == 0)
+      continue;
+    if (ready < 0) {
+      if (errno == EINTR)
+        continue;
+      return;
+    }
+
+    input_event event{};
+    if (read(fd, &event, sizeof(event)) != static_cast<ssize_t>(sizeof(event)))
+      return;  // the device was unplugged or the module was reloaded
+
+    if (event.type != EV_KEY || event.code != kOmenKey || event.value != 1)
+      continue;
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now - last_press < kDebounce)
+      continue;
+    last_press = now;
+
+    launch_app();
+  }
+}
+
+}  // namespace
+
+int main()
+{
+  std::signal(SIGINT, on_signal);
+  std::signal(SIGTERM, on_signal);
+
+  // Start outside the debounce window so the very first press is never eaten.
+  auto last_press = std::chrono::steady_clock::now() - kDebounce;
+  bool announced = false;
+
+  while (g_running) {
+    const int fd = open_hotkey_device();
+    if (fd < 0) {
+      if (announced) {
+        std::cerr << "victus-hotkeyd: \"" << kDeviceName
+                  << "\" went away, waiting for it to come back" << std::endl;
+        announced = false;
+      }
+      std::this_thread::sleep_for(kRescanDelay);
+      continue;
+    }
+
+    if (!announced) {
+      std::cerr << "victus-hotkeyd: watching \"" << kDeviceName
+                << "\" for the OMEN key" << std::endl;
+      announced = true;
+    }
+
+    watch_device(fd, last_press);
+    close(fd);
+  }
+
+  return 0;
+}

--- a/hotkey/victus-hotkeyd.service
+++ b/hotkey/victus-hotkeyd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Victus Control OMEN key listener
+Documentation=https://github.com/Batuhan4/victus-control
+# Launches the GUI, so it is only meaningful inside a graphical session.
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/victus-hotkeyd
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=graphical-session.target

--- a/meson.build
+++ b/meson.build
@@ -5,3 +5,4 @@ project('victus-control', 'cpp', 'c',
 
 subdir('backend')
 subdir('frontend')
+subdir('hotkey')

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -206,6 +206,30 @@ install_temperature_monitor() {
     fi
 }
 
+enable_omen_hotkey() {
+    echo "--> Enabling the OMEN key listener..."
+
+    # The binary, the user unit and the udev rule are installed by meson, so
+    # this only has to switch the service on for the desktop user. It opens the
+    # hotkey input device, which the udev rule hands to the victus group.
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        local uid
+        uid="$(id -u "${SUDO_USER}")"
+        if sudo -u "${SUDO_USER}" \
+               XDG_RUNTIME_DIR="/run/user/${uid}" \
+               systemctl --user enable --now victus-hotkeyd.service 2>/dev/null; then
+            echo "Enabled victus-hotkeyd.service for user '${SUDO_USER}'."
+        else
+            echo "Note: could not enable victus-hotkeyd for '${SUDO_USER}' now" \
+                 "(no active session?). It will start on next login."
+        fi
+    else
+        echo "Note: run the installer with sudo from your desktop user to" \
+             "auto-enable the OMEN key. Otherwise enable it with:" \
+             "systemctl --user enable --now victus-hotkeyd.service"
+    fi
+}
+
 install_hp_wmi_dkms() {
     local wmi_root="wmi-project"
     local wmi_repo="${wmi_root}/hp-wmi-fan-and-backlight-control"
@@ -262,7 +286,8 @@ start_services() {
     systemd-tmpfiles --create || echo "Warning: Failed to create tmpfiles, continuing..."
     systemctl daemon-reload
     udevadm control --reload-rules
-    udevadm trigger --subsystem-match=hwmon --subsystem-match=leds || true
+    # input is included for the OMEN key rule, which sits on the hotkey device.
+    udevadm trigger --subsystem-match=hwmon --subsystem-match=leds --subsystem-match=input || true
     # The four-zone RGB rule sits on the platform device, not on hwmon/leds.
     udevadm trigger --subsystem-match=platform --sysname-match=hp-wmi || true
     udevadm settle || true
@@ -281,6 +306,7 @@ install_helpers_and_sudoers
 install_temperature_monitor
 install_hp_wmi_dkms
 build_and_install_app
+enable_omen_hotkey
 start_services
 
 echo


### PR DESCRIPTION
## What this adds

The dedicated **OMEN key** above the keyboard did nothing on Linux. This makes it open the Victus Control dashboard.

The `hp-wmi` driver already reports it — nothing was listening. Confirmed by reading the driver's own keymap over `EVIOCGKEYCODE_V2` rather than guessing:

```
scancode     keycode  name
0x000021a5   149      KEY_PROG2
0x000021a8   149      KEY_PROG2   <- the OMEN key
```

### `victus-hotkeyd`

A small daemon that watches for `KEY_PROG2` and runs `victus-control`.

- **Finds the device by name**, not by event number — `/dev/input/eventN` is not stable across reboots or DKMS rebuilds.
- **Re-scans every 5 s** if the device disappears, so `modprobe -r hp_wmi` during an install or a DKMS rebuild does not require restarting the service.
- **Debounces** at 400 ms; the firmware sometimes reports one physical press twice.
- Double-forks the GUI, so it never accumulates zombies however often the key is pressed.

It ships as a **user** unit rather than a system one, because it launches a GUI and has to live in the session that owns the display.

### Permissions

`99-victus-hotkey.rules` grants the hotkey device to the `victus` group, matching how the fan and backlight nodes are already handled.

That device carries only the firmware hotkeys — brightness, mic mute, OMEN — and never the typing keyboard, so **this exposes no keystrokes**. It is deliberately narrower than adding the user to the `input` group, which would hand over every input device including the real keyboard.

### Single instance

The frontend becomes a `GtkApplication`. Without it every press would stack up another dashboard; now a second press raises the window that is already open. The `.desktop` file gains a matching `StartupWMClass` so the shell still pairs the window with the launcher.

---

## Second commit: fan-mode guard

`fix(fan): keep the firmware curve when the board exposes no fan target` is **independent** of the OMEN key and happy to be split into its own PR if you'd prefer.

`MANUAL` (and `BETTER_AUTO`, which drives the fans through `MANUAL`) turns the firmware curve off and then writes `fanN_target`. On a board with no target only the first half happens: `pwm1_enable` goes to 1, every target write fails, and the fans are left wherever they were with nothing managing cooling.

Observed on **8E5F / Victus 15-fb3xxx**, where `hp-wmi/hwmon/hwmonN/` exposes only `fan1_input`, `fan2_input`, `pwm1_enable` — no targets, with the patched module loaded. The backend logged this every few seconds:

```
COMMAND=/usr/bin/set-fan-mode.sh MANUAL          <- succeeded
COMMAND=/usr/bin/set-fan-speed.sh 1 4171
victus-backend: Failed to execute set-fan-speed.sh for fan 1. Exit code: 1
```

The guard refuses only that combination. `AUTO` and `MAX` are driven by `pwm1_enable` alone and keep working; boards that do expose `fanN_target` are unaffected.

---

## Hardware validation

Tested on **HP Victus 15-fb3xxx (board 8E5F)**, Ubuntu 26.10, kernel 7.0.0-30, GTK4, single-zone keyboard.

| Check | Result |
| --- | --- |
| OMEN key opens the dashboard | works |
| Second press raises, does not duplicate | works |
| Synthetic `KEY_PROG2` via `uinput` | app launched |
| Device removal / re-scan recovery | recovered, logged `"HP WMI hotkeys" went away, waiting for it to come back` |
| `AUTO` / `MAX` fan modes | `pwm1_enable` 2 / 0 |
| `MANUAL` on a board with no target | refused, stays on AUTO |
| Keyboard colour + brightness writes | `SET`/`GET` round-trip OK |
| CPU / GPU temp, fan RPM reads | OK |
| `meson test` | 2/2 pass |

Because this board has no fan targets, `GET_FAN_TARGET_SUPPORT` reports `UNSUPPORTED` and the UI already hides manual speed — so the guard is belt-and-braces for anything that calls the script directly.

I don't have a four-zone Omen board to test against; the hotkey path is independent of zone count, but a second pair of eyes there would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELZkKrF8iHGDQG3qK19xcG
